### PR TITLE
Feat: seção de livros nacionais

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Coletânea de links e fontes de conteúdo brasileiro sobre hacking, segurança da informação e tópicos relacionados.
 
 ## Aviso Legal
-Todo conteúdo aqui apresentado é destinado única e exclusivamente para profissionais de segurança da informação ou entusiastas que almejam ingressar na área. Portanto somos completamente contrários o uso do conhecimneto para práticas ilegais. Lembre-se, o que difere um excelente profissional de cybersecurity e um cibercriminoso é a ética. 
+Todo conteúdo aqui apresentado é destinado única e exclusivamente para profissionais de segurança da informação ou entusiastas que almejam ingressar na área. Portanto, somos completamente contrários o uso do conhecimento para práticas ilegais. Lembre-se, o que difere um excelente profissional de cybersecurity e um cibercriminoso é a ética. 
 
 ## Tópicos
 

--- a/pages/livros.md
+++ b/pages/livros.md
@@ -9,14 +9,54 @@
         <td>Descrição</td>
     </tr>
     <tr>
-        <td><a href="menteb.in/livro"> Fundamentos da engenharia reversa </a></td>
+        <td><a target="_blank" href="https://mentebinaria.gitbook.io/engenharia-reversa/"> Fundamentos da engenharia reversa </a></td>
         <td>Fernando Mercês (@mer0x36) </td>
         <td>Este livro é mais um projeto da Mente Binária. Ele consiste o resultado de um extenso trabalho de organização de conteúdo e escrita após centenas de horas de aulas ministradas sobre engenharia reversa de software para iniciantes. A intenção é documentar os conhecimentos fundamentais necessários para a formação dos novos engenheiros reversos.</td>
     </tr>
     <tr>
-        <td> <a href="https://www.livrodeseguranca.com/"> Gestão da Segurança da Informação: Uma visão executiva</td>
+        <td> <a target="_blank" href="https://www.livrodeseguranca.com/"> Gestão da Segurança da Informação: Uma visão executiva</td>
         <td>Marcos Sêmola</td>
         <td>Passados 20 anos de escrito e editado, tempo em que as práticas de gestão de segurança da informação ainda eram um "mato alto”, chegou o momento de tornar pública a íntegra do best seller que, por anos, serviu de referência para professores, graduandos, mestrandos, doutorandos e profissionais de gestão de riscos que hoje atuam no mercado de trabalho.</td>
+</table>
+
+## Nacionais
+
+<table>
+    <tr>
+        <td>Livro</td>
+        <td>Autor</td>
+        <td>Descrição</td>
+    </tr>
+    <tr>
+        <td>
+            <a target="_blank" href="https://amzn.to/3tQEcwc">Pentest em Aplicações web</a>
+        </td>
+        <td>Daniel Moreno</td>
+        <td>Aplicações web têm um histórico extenso de vulnerabilidades, que têm sido exploradas pelos hackers. A lista de ataques conhecidos é extensa, envolvendo Cross-site Scripting, SQL Injection, unrestricted file upload, Code Injection, Command Injecion, Remote/Local File Inclusion e Cross-site Request Forgery, somente para citar alguns. Neste livro, você conhecerá as técnicas mais utilizadas pelos hackers, e poderá implementar mecanismos de proteção em suas aplicações web contra esses ataques. Para facilitar, esta obra é dividida em três seções. A primeira tem como foco ensinar o básico sobre ambientes web, sendo o PHP a linguagem escolhida. Entendendo bem a primeira seção, a segunda reportará como os ataques são realizados. Nessa parte, ferramentas e técnicas manuais de ataques serão descritas a fim de se conhecer quais as possíveis vulnerabilidades do website. As técnicas de defesa serão descritas na terceira seção, para que o website seja disponibilizado on-line com o mínimo de segurança. No decorrer do livro, o leitor aprenderá:Os princípios da programação web (HTML, CSS, PHP e SQL) e quais as funções do PHP com que se deve ter mais cuidado; A realizar um pentest na própria aplicação seguindo as normas da OWASP e saber qual é o modus operandi de um ataque; A analisar um código PHP e determinar se este está ou não vulnerável. </td>
+    </tr>
+    <tr>
+        <td>
+            <a target="_blank" href="https://amzn.to/3ApKYud">Pentest em Redes sem fio</a>
+        </td>
+        <td>Daniel Moreno</td>
+        <td>Pentest em redes sem fio tem o intuito de capacitar o leitor a entender e realizar o pentest em redes sem fio. Como complemento da obra Introdução ao pentest, do mesmo autor, este livro é focado exclusivamente em redes sem fio, mostrando as principais formas de ataque que um indivíduo mal-intencionado pode utilizar para acessar a sua rede sem fio. Simulando o pensamento de um cracker, este livro apresenta os passos e as técnicas necessárias para se obter o acesso à rede sem fio: Conhecer o funcionamento de uma rede sem fio na teoria e na prática: quais são os principais tipos de criptografia e como funcionam. Testar laboratórios e ambientes simulados: vamos entender por que os principais sistemas criptográficos falham e por que é tão simples hackear uma rede sem fio. Realizar o mapeamento de redes sem fio com softwares específicos para essa finalidade (GPS USB) e descobrir a localização física dos pontos de acesso. Saber como se defender por meio dos softwares de monitoramento e de detecção de intruso (wIDS e wIPS). Aprender a criar, de forma didática e explicativa, as redes sem fio mais seguras que existem: redes empresariais com certificados digitais autoassinados. Com todo esse armamento em mãos, realizar uma simulação de pentest e, ao final, aprender como é feita a escrita de um relatório de pentest para redes sem fio. </td>
+    </tr>
+    <tr>
+        <td>
+            <a target="_blank" href="https://www.amazon.com.br/gp/product/8575228072/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=8575228072&linkCode=as2&tag=novatec03-20">Introdução ao Pentest</a>
+        </td>
+        <td>
+            Daniel Moreno
+        </td>
+        <td>
+             Introdução ao Pentest irá capacitar o leitor a entender e a realizar o pentest – uma auditoria minuciosa sobre falhas e vulnerabilidades em computadores e redes – e, assim, buscar a melhor forma de solucionar os problemas encontrados. Tendo como base a metodologia Kali Linux para o ensino do pentest, a qual é extremamente didática e adaptada a partir da metodologia PTES de testes de invasão, com certeza este livro fará você se sentir à vontade e confiante ao estudar pentest, tornando o seu aprendizado fácil e rápido. O leitor terá acesso às táticas e técnicas utilizadas no pentest em um ambiente controlado por laboratório e máquinas virtuais. Cada capítulo aborda uma etapa do pentest e, no decorrer da leitura, você aprenderá: Os aspectos básicos de segurança da informação, como a instalação de máquinas virtuais e os primeiros passos com o Kali Linux, criar redes zumbie para ataques DDoS utilizando o IRC como rede mestre, realizar a evasão de sistemas de antivírus usando as linguagens de programação C, Python e Powershell, os princípios básicos do desenvolvimento de exploits, usar o framework Metasploit, etc.
+        </td>
+    </tr>
+    <tr>
+    	<td><a target="_blank" href="https://www.amazon.com.br/gp/product/8575223755/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=8575223755&linkCode=as2&tag=novatec03-20">Análise de Tráfego em Redes TCP/IP</a></td>
+    	<td>João Eriberto Mota Filho</td>
+    	<td>O grande objetivo deste livro é mostrar como realizar a análise de tráfego em redes. A nova geração IP (IPv6) também é abordada com certa profundidade, garantindo um bom entendimento sobre essa tecnologia. Este livro utiliza o tcpdump, exaustivamente, para demonstrar a teoria com base em capturas de tráfego e, consequentemente, ensinar sua análise. Todo o trabalho está dividido em uma introdução e cinco partes, a saber: conceitos básicos; protocolos básicos em redes TCP/IP e sua análise; conhecimentos específicos em redes TCP/IP e sua análise; tráfegos diversos e sistemas específicos; apêndices. É feita uma ampla abordagem sobre protocolos de rede e assuntos correlatos, como IPv4, IPv6, TCP, UDP, ICMP, Ethernet, ARP e NDP, Modelo OSI, roteamento em redes, bridges e sistemas de firewall. Também serão realizados trabalhos com simuladores de redes e programas para detectar invasões. Por seu conteúdo, este livro poderá ser utilizado tanto por autodidatas quanto por universitários de graduação e pós-graduação. É um livro direcionado a todos que empregam TCP/IP dentro de uma rede de computadores, independentemente do sistema operacional utilizado. A análise de tráfego poderá ser feita em qualquer ambiente e os conhecimentos aqui disponibilizados são universais.</td>
+    </tr>
 </table>
 
 ## Traduções
@@ -37,33 +77,12 @@
     </tr>
         <tr>
         <td>
-            <a target="_black" href="https://amzn.to/3tP9VxW">Ransomware: Defendendo-se da Extorsão Digital</a>
+            <a target="_blank" href="https://amzn.to/3tP9VxW">Ransomware: Defendendo-se da Extorsão Digital</a>
         </td>
         <td> Allan Liska</td>
         <td>A principal ameaça online aos negócios e consumidores atualmente é o ransomware: uma categoria de malware capaz de criptografar os arquivos de seu computador até que você pague um resgate para desbloqueá-los. Com este livro prático, você verá como os ransomwares podem infectar seu sistema e como interromper o ataque antes que atinjam a rede.
         Os autores explicam como o sucesso desses ataques deu origem não só a muitas variantes de ransomware, mas também a diversas maneiras continuamente em evolução de atingir seus alvos. Você conhecerá métodos pragmáticos para responder rapidamente a um ataque de ransomware, assim como meios de se proteger para não ser infectado.
         Aprenda como um ransomware entra em seu sistema e criptografa seus arquivos. Entenda por que o uso de ransomware tem aumentado, especialmente nos últimos anos. Analise as organizações responsáveis pelos ransomwares e as vítimas visadas. Aprenda como os aspirantes a hackers usam RaaS (Ransomware as a Service) para lançar campanhas. Entenda como o resgate é pago – e os prós e contras de efetuar o pagamento. Use métodos para proteger as estações de trabalho e os servidores de sua empresa.</td>
-    </tr>
-    <tr>
-        <td>
-            <a target="_blank" href="https://amzn.to/3nPPT2C"> Introdução ao Pentest</a> 
-        </td>
-        <td>Georgia Weidman</td>
-        <td> Introdução ao Pentest irá capacitar o leitor a entender e a realizar o pentest – uma auditoria minuciosa sobre falhas e vulnerabilidades em computadores e redes – e, assim, buscar a melhor forma de solucionar os problemas encontrados. Tendo como base a metodologia Kali Linux para o ensino do pentest, a qual é extremamente didática e adaptada a partir da metodologia PTES de testes de invasão, com certeza este livro fará você se sentir à vontade e confiante ao estudar pentest, tornando o seu aprendizado fácil e rápido.</td>
-    </tr>
-    <tr>
-        <td>
-            <a target="_blank" href="https://amzn.to/3tQEcwc">Pentest em Aplicações web</a>
-        </td>
-        <td>Daniel Moreno</td>
-        <td>Aplicações web têm um histórico extenso de vulnerabilidades, que têm sido exploradas pelos hackers. A lista de ataques conhecidos é extensa, envolvendo Cross-site Scripting, SQL Injection, unrestricted file upload, Code Injection, Command Injecion, Remote/Local File Inclusion e Cross-site Request Forgery, somente para citar alguns. Neste livro, você conhecerá as técnicas mais utilizadas pelos hackers, e poderá implementar mecanismos de proteção em suas aplicações web contra esses ataques. Para facilitar, esta obra é dividida em três seções. A primeira tem como foco ensinar o básico sobre ambientes web, sendo o PHP a linguagem escolhida. Entendendo bem a primeira seção, a segunda reportará como os ataques são realizados. Nessa parte, ferramentas e técnicas manuais de ataques serão descritas a fim de se conhecer quais as possíveis vulnerabilidades do website. As técnicas de defesa serão descritas na terceira seção, para que o website seja disponibilizado on-line com o mínimo de segurança. No decorrer do livro, o leitor aprenderá:Os princípios da programação web (HTML, CSS, PHP e SQL) e quais as funções do PHP com que se deve ter mais cuidado; A realizar um pentest na própria aplicação seguindo as normas da OWASP e saber qual é o modus operandi de um ataque; A analisar um código PHP e determinar se este está ou não vulnerável. </td>
-    </tr>
-    <tr>
-        <td>
-            <a target="_blank" href="https://amzn.to/3ApKYud">Pentest em Redes sem fio</a>
-        </td>
-        <td>Daniel Moren</td>
-        <td>Pentest em redes sem fio tem o intuito de capacitar o leitor a entender e realizar o pentest em redes sem fio. Como complemento da obra Introdução ao pentest, do mesmo autor, este livro é focado exclusivamente em redes sem fio, mostrando as principais formas de ataque que um indivíduo mal-intencionado pode utilizar para acessar a sua rede sem fio. Simulando o pensamento de um cracker, este livro apresenta os passos e as técnicas necessárias para se obter o acesso à rede sem fio: Conhecer o funcionamento de uma rede sem fio na teoria e na prática: quais são os principais tipos de criptografia e como funcionam. Testar laboratórios e ambientes simulados: vamos entender por que os principais sistemas criptográficos falham e por que é tão simples hackear uma rede sem fio. Realizar o mapeamento de redes sem fio com softwares específicos para essa finalidade (GPS USB) e descobrir a localização física dos pontos de acesso. Saber como se defender por meio dos softwares de monitoramento e de detecção de intruso (wIDS e wIPS). Aprender a criar, de forma didática e explicativa, as redes sem fio mais seguras que existem: redes empresariais com certificados digitais autoassinados. Com todo esse armamento em mãos, realizar uma simulação de pentest e, ao final, aprender como é feita a escrita de um relatório de pentest para redes sem fio. </td>
     </tr>
     <tr>
         <td>


### PR DESCRIPTION
O mesmo conteúdo do PR anterior que cancelei se encontra aqui, porém com algumas adições e correções, a saber:

Foi adicionado uma seção para os livros nacionais. Dessa forma, as obras de autores nacionais ficam em separado e com um destaque maior quando em face dos livros estrangeiros traduzidos.

Os livros do Daniel Moreno foram retirados da seção de traduções e adicionados na seção de livros nacionais, juntamente com o livro de Análise de Tráfego do Eriberto Mota. Também foi retirado o livro da Georgia Weidman que estava duplicado na seção de traduções e mantido apenas um. 

Por fim, o link para o livro do Mente Binária foi consertado (anteriormente estava levando a uma página inexistente no GitHub) e o README foi consertado.